### PR TITLE
Add forRoot method to Module

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,7 +22,7 @@ import {HttpClientModule} from '@angular/common/http';
     HttpClientModule,
     FormsModule,
     MatButtonModule, MatSelectModule, MatInputModule, MatCheckboxModule, MatGridListModule, MatFormFieldModule,
-    CgBusyModule
+    CgBusyModule.forRoot()
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/lib/cgBusy.module.ts
+++ b/src/lib/cgBusy.module.ts
@@ -36,10 +36,7 @@ export class CgBusyModule {
 }
 
 export function cgBusyDefaultsFactory(busyOptions?: CgBusyOptions): CgBusyDefaults {
-console.log('factory');
-  const busyDefaults = new CgBusyDefaults(busyOptions);
-
-  return busyDefaults;
+  return new CgBusyDefaults(busyOptions);
 }
 
 export const BUSY_OPTIONS = new InjectionToken<CgBusyOptions>('BUSY_OPTIONS');

--- a/src/lib/cgBusy.module.ts
+++ b/src/lib/cgBusy.module.ts
@@ -1,5 +1,5 @@
 import {CommonModule} from '@angular/common';
-import {NgModule} from '@angular/core';
+import {ModuleWithProviders, NgModule} from '@angular/core';
 import {CgBusyDirective} from './cgBusy.directive';
 import {CgBusyDefaults} from './cgBusyDefaults.service';
 import {CgBusyComponent} from './cgBusy.component';
@@ -14,7 +14,17 @@ import {CgBusyComponent} from './cgBusy.component';
   ],
   exports: [CgBusyDirective],
   entryComponents: [CgBusyComponent],
-  providers: [CgBusyDefaults]
 })
 export class CgBusyModule {
+  static forRoot(busyConfig?: CgBusyDefaults): ModuleWithProviders {
+    return {
+      ngModule: CgBusyModule,
+      providers: [
+        {
+          provide: CgBusyDefaults,
+          useValue: busyConfig ? busyConfig : new CgBusyDefaults()
+        }
+      ]
+    };
+  }
 }

--- a/src/lib/cgBusy.module.ts
+++ b/src/lib/cgBusy.module.ts
@@ -1,8 +1,9 @@
 import {CommonModule} from '@angular/common';
-import {ModuleWithProviders, NgModule} from '@angular/core';
+import {InjectionToken, ModuleWithProviders, NgModule} from '@angular/core';
 import {CgBusyDirective} from './cgBusy.directive';
 import {CgBusyDefaults} from './cgBusyDefaults.service';
 import {CgBusyComponent} from './cgBusy.component';
+import {CgBusyOptions} from './cgBusy.interface';
 
 @NgModule({
   declarations: [
@@ -16,15 +17,29 @@ import {CgBusyComponent} from './cgBusy.component';
   entryComponents: [CgBusyComponent],
 })
 export class CgBusyModule {
-  static forRoot(busyConfig?: CgBusyDefaults): ModuleWithProviders {
+  static forRoot(busyOptions?: CgBusyOptions): ModuleWithProviders {
     return {
       ngModule: CgBusyModule,
       providers: [
         {
           provide: CgBusyDefaults,
-          useValue: busyConfig ? busyConfig : new CgBusyDefaults()
+          useFactory: cgBusyDefaultsFactory,
+          deps: [BUSY_OPTIONS]
+        },
+        {
+          provide: BUSY_OPTIONS,
+          useValue: busyOptions
         }
       ]
     };
   }
 }
+
+export function cgBusyDefaultsFactory(busyOptions?: CgBusyOptions): CgBusyDefaults {
+console.log('factory');
+  const busyDefaults = new CgBusyDefaults(busyOptions);
+
+  return busyDefaults;
+}
+
+export const BUSY_OPTIONS = new InjectionToken<CgBusyOptions>('BUSY_OPTIONS');

--- a/src/lib/cgBusy.module.ts
+++ b/src/lib/cgBusy.module.ts
@@ -5,6 +5,12 @@ import {CgBusyDefaults} from './cgBusyDefaults.service';
 import {CgBusyComponent} from './cgBusy.component';
 import {CgBusyOptions} from './cgBusy.interface';
 
+export function cgBusyDefaultsFactory(busyOptions?: CgBusyOptions): CgBusyDefaults {
+  return new CgBusyDefaults(busyOptions);
+}
+
+export const BUSY_OPTIONS = new InjectionToken<CgBusyOptions>('BUSY_OPTIONS');
+
 @NgModule({
   declarations: [
     CgBusyDirective,
@@ -34,9 +40,3 @@ export class CgBusyModule {
     };
   }
 }
-
-export function cgBusyDefaultsFactory(busyOptions?: CgBusyOptions): CgBusyDefaults {
-  return new CgBusyDefaults(busyOptions);
-}
-
-export const BUSY_OPTIONS = new InjectionToken<CgBusyOptions>('BUSY_OPTIONS');

--- a/src/lib/cgBusyDefaults.service.ts
+++ b/src/lib/cgBusyDefaults.service.ts
@@ -1,5 +1,6 @@
-import {Injectable, TemplateRef} from '@angular/core';
+import {Inject, Injectable, TemplateRef} from '@angular/core';
 import {CgBusyOptions} from './cgBusy.interface';
+import {BUSY_OPTIONS} from './cgBusy.module';
 
 @Injectable()
 export class CgBusyDefaults implements CgBusyOptions {
@@ -10,11 +11,18 @@ export class CgBusyDefaults implements CgBusyOptions {
   wrapperClass: string;
   templateRef: TemplateRef<any>;
 
-  constructor() {
-    this.delay = 0;
-    this.minDuration = 0;
-    this.backdrop = true;
-    this.message = 'Please Wait...';
-    this.wrapperClass = '';
+  constructor(@Inject(BUSY_OPTIONS) busyOptions?: CgBusyOptions) {
+
+    if (!busyOptions) {
+      busyOptions = {};
+    }
+
+    this.delay = busyOptions.delay || 0;
+    this.minDuration = busyOptions.minDuration || 0;
+    this.backdrop = busyOptions.backdrop || true;
+    this.message = busyOptions.message || 'Please Wait...';
+    this.wrapperClass = busyOptions.wrapperClass || '';
+
+    console.log(this.message);
   }
 }

--- a/src/lib/cgBusyDefaults.service.ts
+++ b/src/lib/cgBusyDefaults.service.ts
@@ -19,7 +19,7 @@ export class CgBusyDefaults implements CgBusyOptions {
 
     this.delay = busyOptions.delay || 0;
     this.minDuration = busyOptions.minDuration || 0;
-    this.backdrop = busyOptions.backdrop || true;
+    this.backdrop = busyOptions.backdrop !== undefined ? busyOptions.backdrop : true;
     this.message = busyOptions.message || 'Please Wait...';
     this.wrapperClass = busyOptions.wrapperClass || '';
   }

--- a/src/lib/cgBusyDefaults.service.ts
+++ b/src/lib/cgBusyDefaults.service.ts
@@ -22,7 +22,5 @@ export class CgBusyDefaults implements CgBusyOptions {
     this.backdrop = busyOptions.backdrop || true;
     this.message = busyOptions.message || 'Please Wait...';
     this.wrapperClass = busyOptions.wrapperClass || '';
-
-    console.log(this.message);
   }
 }


### PR DESCRIPTION
added static forRoot method

usually you want a default for your CgBusyDefaults for the whole application.
Since it got "provided" every time you import the module
(which you must if you want to use the directive in a
lazy loaded module or a submodule) the defaults got
overwritten everytime.

Now it is provided in forRoot which has to be called in your app.module.

Like
```
CgBusyModule.forRoot()
// or
CgBusyModule.forRoot({ message: 'foobar'})
```
`CgBusyDefaults` constructor now accepts a `CgBusyOptions` object via InjectionToken.

if you don't provide an option value (like delay) the default will be used (like before)

This is a breaking change since you have to call `forRoot` in your `app.module` otherwise `CgBusyDefaults` won't be provided.